### PR TITLE
Fix initial menu bug + small fixes

### DIFF
--- a/src/chrysalis/app.cljs
+++ b/src/chrysalis/app.cljs
@@ -49,9 +49,10 @@
 (re-frame/reg-event-fx
  :db
  [(re-frame/inject-cofx :settings/load)]
- (fn [{:keys [settings]} _]
-   {:db {:page/current :devices
-         :settings settings}}))
+ (fn [{:keys [settings db]} _]
+   {:db (assoc db
+               :page/current :devices
+               :settings settings)}))
 
 (re-frame/reg-event-fx
  :settings/window

--- a/src/chrysalis/ui.cljs
+++ b/src/chrysalis/ui.cljs
@@ -50,9 +50,9 @@
 ;;; ---- Main application ---- ;;;
 (defn chrysalis []
   [:div
-   (style)
+   [style]
    [<about>]
-   (<main-menu>)
+   [<main-menu>]
 
    [:div {:id :page}
     (when-let [page (page/current)]

--- a/src/chrysalis/ui/main_menu.cljs
+++ b/src/chrysalis/ui/main_menu.cljs
@@ -52,7 +52,8 @@
                                               (page/list)))]
        (doall
         (for [[index menu-item] pages]
-          (<menu-item> menu-item index))))
+          ^{:key index}
+          [<menu-item> menu-item index])))
      [:hr]
      [:a.dropdown-item {:href "#about"
                         :data-toggle :modal} "About"]


### PR DESCRIPTION
Small changes to match how reagent needs thing to be structured + fixing a bug where on initial load, some menu items are missing.

The bug behaviour was happening because the `:settings/load` dispatch wipes the current value of `:db`, but since plugins add themselves to there when required, there is a race condition.